### PR TITLE
v18 with additional fail-safe checks

### DIFF
--- a/Nudge-Post-install.bash
+++ b/Nudge-Post-install.bash
@@ -7,8 +7,10 @@
 #   Purpose: Configures Nudge to company standards post-install
 #   https://github.com/dan-snelson/Nudge-Post-install/wiki
 #
-#   Based on version 0.0.17, 03-Jan-2023, Dan K. Snelson (@dan-snelson)
-#   Updates for Nudge [`1.1.10`](https://github.com/macadmins/nudge/pull/435)
+#   Original author:
+#   Dan K. Snelson (@dan-snelson)
+#   Nudge Updates:
+#   see notes for version [`1.1.10`](https://github.com/macadmins/nudge/pull/435)
 #
 ####################################################################################################
 
@@ -64,7 +66,7 @@ requiredForceDownloadURL="${11:-"https://swcdn.apple.com/content/downloads/26/09
 # Global Variables
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-scriptVersion="1.2.0"
+scriptVersion="18.0.0"
 export PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin/
 loggedInUser=$( echo "show State:/Users/ConsoleUser" | scutil | awk '/Name :/ { print $3 }' )
 
@@ -300,7 +302,7 @@ if [[ ! -f "${scriptLog}" ]]; then
 fi
 
 # Logging preamble
-updateScriptLog "Nudge Post-install modified by @lapc506 - version: (${scriptVersion})"
+updateScriptLog "Nudge Post-install - version: (${scriptVersion})"
 
 # Reset Configuration
 resetConfiguration "${resetConfiguration}"

--- a/Nudge-Post-install.bash
+++ b/Nudge-Post-install.bash
@@ -40,8 +40,8 @@ requiredTargetedOSVersionsRule="${8:-"13"}"
 
 requiredAboutUpdateURL="${9:-"aboutUpdateURL"}"
 
-requiredMainContentText="${9:-"mainContentText"}"
-requiredSubHeader="${10:-"subHeader"}"
+requiredMainContentText="${10:-"mainContentText"}"
+requiredSubHeader="${11:-"subHeader"}"
 
 scriptLog="/var/log/${plistDomain}.NudgePostInstall.log"
 jsonPath="/Library/Preferences/${plistDomain}.Nudge.json"


### PR DESCRIPTION
- Simplified functions used by `resetConfiguration` according to [DRY principle](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself).
- Simplified Jamf Parameter Labels and `osVersionRequirements` inputs to have one single `requiredInstallationDate` while making `targetedOSVersionsRule` on the local JSON file a multi-target version list (separated by commas as stated on the Nudge wiki).
- Added references to the Nudge wiki for each Jamf Parameter Label for easier maintenance.
- Updated for macOS Sonoma 14.0.
- `requiredForceDownloadURL` is now available as a Jamf policy parameter in case anyone wants to use a different source
- Added new global variables for Jamf policy parameters: `requiredMinimumOSInstallerFilename`, `requiredMinimumOSInstallerVersion`, `shouldForceDownload`, `requiredAboutUpdateURL`, `requiredTargetedOSVersionsRule`
- Added new functions `validateOSInstallerVersion`, `forceDownloadLatestUpgrade` which improve cleaning up the temp and Applications folders, for use cases where multiple OS minor updates have been historically deployed for a same single major upgrade _(e.g. 13.x.x all Ventura minor update versions)_
- Set default values for `aggressiveUserExperience` and `aggressiveUserFullScreenExperience` to `false`
- Removed `actionButtonPath` from `userInterface` on the local JSON setup to set the default behavior as redirecting users to the Software Update native tool that does not require a working [authenticated reboot on the script](https://community.jamf.com/t5/jamf-pro/macos-installer-script-not-working-for-apple-silicon-m1-macbook/m-p/251374/highlight/true#M234155) for M1 and M2-based Macs (as opposed to using Jamf Self Service, Munki or other tools by default).
- Modified `updateElements` to align closer to the [example standard mode screenshots provided on the Nudge wiki](https://github.com/macadmins/nudge/blob/main/README.md#standardmode).
- Modified default location of log file to `/var/log/${plistDomain}.NudgePostInstall.log` where `plistDomain` is now a set by default to "`org.corp.app`" unless otherwise specified by IT admin using this script on a Jamf policy.
